### PR TITLE
Handle booleans

### DIFF
--- a/src/lib/component-base.php
+++ b/src/lib/component-base.php
@@ -41,7 +41,8 @@ abstract class Element extends PrimaryComponent {
       if (is_long($key)) {
         array_push($children, $value);
       } else if (!in_array($key, Element::SPECIAL_FIELDS)) {
-        $attributes[$key] = $value;
+        if ($value === false) continue;
+        $attributes[$key] = $value === true ? $key : $value;
       }
     }
 


### PR DESCRIPTION
Allow attributes as booleans

### Example

#### PHP Script

```php
return HtmlElement::create('foo-bar', [
  'true-attribute' => true,
  'false-attribute' => false,
  'text-attribute' => 'text',
  'Content',
]);
```

#### Resulting HTML

```html
<foo-bar true-attribute="true-attribute" text-attribute="text">
  Content
</foo-bar>
```