### PR TITLE
Improve component marking

### DIFF
--- a/src/lib/render.php
+++ b/src/lib/render.php
@@ -35,8 +35,10 @@ class Renderer {
 
     $attributes = $this->renderAttributes(array_merge(
       $element->attributes,
-      ['x-component-level' => (string) $level],
-      ['x-component' => implode(' ', $classmap['set'])]
+      [
+        'x-component-level' => (string) $level,
+        'x-component' => implode(' ', $classmap['set']),
+      ]
     ));
 
     $classes = $this->renderClassAttribute(array_merge(

--- a/src/lib/render.php
+++ b/src/lib/render.php
@@ -37,7 +37,7 @@ class Renderer {
       $element->attributes,
       [
         'x-component-level' => (string) $level,
-        'x-component' => implode(' ', $classmap['set']),
+        'x-component-set' => implode(' ', $classmap['set']),
         'x-component-tree' => json_encode($classmap['tree']),
       ]
     ));

--- a/src/lib/render.php
+++ b/src/lib/render.php
@@ -31,7 +31,6 @@ class Renderer {
 
   private function renderElement(Element $element, int $level, array $compClassNames): string {
     $tag = $element->tag;
-
     $classmap = Renderer::makeComponentClassMap($compClassNames);
 
     $attributes = $this->renderAttributes(array_merge(

--- a/src/lib/render.php
+++ b/src/lib/render.php
@@ -38,6 +38,7 @@ class Renderer {
       [
         'x-component-level' => (string) $level,
         'x-component' => implode(' ', $classmap['set']),
+        'x-component-tree' => json_encode($classmap['tree']),
       ]
     ));
 

--- a/src/lib/render.php
+++ b/src/lib/render.php
@@ -32,10 +32,12 @@ class Renderer {
   private function renderElement(Element $element, int $level, array $compClassNames): string {
     $tag = $element->tag;
 
+    $classmap = Renderer::makeComponentClassMap($compClassNames);
+
     $attributes = $this->renderAttributes(array_merge(
       $element->attributes,
       ['x-component-level' => (string) $level],
-      ['x-component' => implode(' ', $compClassNames)]
+      ['x-component' => implode(' ', $classmap['set'])]
     ));
 
     $classes = $this->renderClassAttribute(array_merge(
@@ -48,7 +50,7 @@ class Renderer {
           return 'x-component--' . $kebab;
         },
 
-        $compClassNames
+        $classmap['set']
       )
     ));
 
@@ -167,6 +169,35 @@ class Renderer {
         }
       )
     );
+  }
+
+  static private function makeComponentClassMap(array $list): array {
+    $set = [];
+    $tree = [];
+
+    foreach($list as $component) {
+      $checker = new ClassChecker($component);
+      if (!$checker->didImplemented('Component')) continue;
+      if ($checker->didExtended('PrimaryComponent')) continue;
+
+      $unit = array_merge(
+        [$component => $component],
+        array_filter(
+          $checker->getParents(),
+          function (string $class): bool {
+            return in_array('Component', class_implements($class));
+          }
+        )
+      );
+
+      $set = array_merge($set, $unit);
+      array_push($tree, array_values($unit));
+    }
+
+    return [
+      'set' => array_unique(array_values($set)),
+      'tree' => $tree,
+    ];
   }
 }
 ?>

--- a/src/lib/utils.php
+++ b/src/lib/utils.php
@@ -1,4 +1,33 @@
 <?php
+class ClassChecker {
+  private $parents, $implements;
+
+  public function __construct(string $subject) {
+    $this->parents = class_parents($subject);
+    $this->implements = class_implements($subject);
+  }
+
+  static public function instance(string $subject): self {
+    return new static($subject);
+  }
+
+  public function getParents(): array {
+    return $this->parents;
+  }
+
+  public function getImplements(): array {
+    return $this->implements;
+  }
+
+  public function didExtended(string $class): bool {
+    return in_array($class, $this->getParents());
+  }
+
+  public function didImplemented(string $interface): bool {
+    return in_array($interface, $this->getImplements());
+  }
+}
+
 class CaseConverter {
   private $words;
 


### PR DESCRIPTION
* Rename attribute: `x-component` → `x-component-set`
* Mark all parent component classes (whose names are after `extends`) as `x-component-set`
* Mark class tree as `x-component-tree`